### PR TITLE
Fix missing space in Sbt installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ will need this to run Scala code that I provide)
 
 * [OSX]  From terminal: ```brew install sbt```
 * [Ubuntu] From terminal:<br>
-   ```echo "deb https://dl.bintray.com/sbt/debian/" | sudo tee -a /etc/apt/sources.list.d/sbt.list```<br>
+   ```echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list```<br>
    ```sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823```<br>
    ```sudo apt-get update```<br>
    ```sudo apt-get install sbt```  


### PR DESCRIPTION
Reference: https://www.scala-sbt.org/download.html
Without the space, `sudo apt-get update` would report error:
```
E: Malformed entry 1 in list file /etc/apt/sources.list.d/sbt.list (Suite)
E: The list of sources could not be read.
```